### PR TITLE
Add party entity processing to knowledge base

### DIFF
--- a/knowledge-base/analysis/embedding.py
+++ b/knowledge-base/analysis/embedding.py
@@ -67,7 +67,9 @@ class EmbeddingClient:
                     for segment in batch_segments
                 ]
                 embedding_vectors = await asyncio.gather(*tasks)
-                for segment, embedding_vector in zip(batch_segments, embedding_vectors, strict=False):
+                for segment, embedding_vector in zip(
+                    batch_segments, embedding_vectors, strict=False
+                ):
                     if embedding_vector is not None:
                         segment.embedding = np.array(embedding_vector)
             yield doc  # Yield the processed document

--- a/knowledge-base/graph/__init__.py
+++ b/knowledge-base/graph/__init__.py
@@ -201,12 +201,14 @@ class SchemaManager:
                 SET p.full_name = $full_name
                 """,
                 abbreviation=party.abbreviation,
-                full_name=party.full_name
+                full_name=party.full_name,
             )
 
     def upsert_parties(self, parties: list[Party]) -> None:
         """Bulk insert or update party nodes"""
-        parties_data = [{"abbreviation": p.abbreviation, "full_name": p.full_name} for p in parties]
+        parties_data = [
+            {"abbreviation": p.abbreviation, "full_name": p.full_name} for p in parties
+        ]
         with self.driver.session() as session:
             session.run(
                 """
@@ -214,7 +216,7 @@ class SchemaManager:
                 MERGE (p:Party {abbreviation: party.abbreviation})
                 SET p.full_name = party.full_name
                 """,
-                parties=parties_data
+                parties=parties_data,
             )
 
     def link_documents_to_parties(self) -> None:
@@ -233,11 +235,14 @@ class SchemaManager:
             "socialdemokraterna": "S",
             "sverigedemokraterna": "SD",
             "vansterpartiet": "V",
-            "kristdemokraterna": "KD"
+            "kristdemokraterna": "KD",
         }
 
         with self.driver.session() as session:
             for folder_name, party_abbr in folder_to_party_mapping.items():
+                print(
+                    f"Linking documents to party {party_abbr} from folder {folder_name}"
+                )
                 session.run(
                     """
                     MATCH (d:Document)
@@ -246,7 +251,7 @@ class SchemaManager:
                     MERGE (p)-[:AUTHORED]->(d)
                     """,
                     folder_pattern=f"/documents/{folder_name}/",
-                    party_abbr=party_abbr
+                    party_abbr=party_abbr,
                 )
 
 

--- a/knowledge-base/main.py
+++ b/knowledge-base/main.py
@@ -10,8 +10,7 @@ from tqdm.asyncio import tqdm as async_tqdm
 
 # Configure logging
 logging.basicConfig(
-    level=logging.INFO,
-    format='%(asctime)s - %(name)s - %(levelname)s - %(message)s'
+    level=logging.INFO, format="%(asctime)s - %(name)s - %(levelname)s - %(message)s"
 )
 logger = logging.getLogger(__name__)
 
@@ -47,10 +46,10 @@ def process_party_entities(schema_manager: SchemaManager) -> None:
     logger.info("Processing party entities...")
 
     # Load parties from JSON file
-    parties_path = Path("knowledge-base/documents/voting/parties.json")
+    parties_path = Path("documents/voting/parties.json")
     if not parties_path.exists():
         logger.error(f"Parties file not found at {parties_path}")
-        return
+        raise FileNotFoundError(f"Parties file not found at {parties_path}")
 
     with open(parties_path, encoding="utf-8") as f:
         parties_data = json.load(f)
@@ -59,10 +58,7 @@ def process_party_entities(schema_manager: SchemaManager) -> None:
     parties = []
     for abbr, full_name in parties_data["parties"].items():
         if abbr != "-":  # Skip "Partilös" (independent)
-            parties.append(Party(
-                abbreviation=abbr,
-                full_name=full_name
-            ))
+            parties.append(Party(abbreviation=abbr, full_name=full_name))
 
     # Import to Neo4j
     schema_manager.upsert_parties(parties)
@@ -280,9 +276,6 @@ async def main():
         schema_manager.apply_schema()
         print("Schema applied successfully.")
 
-        # Process party entities
-        process_party_entities(schema_manager)
-
         print("Upserting topics...")
         for topic in tqdm(topics, desc="Upserting topics", unit="topic"):
             schema_manager.upsert_topic(topic)
@@ -292,6 +285,11 @@ async def main():
         for doc in tqdm(documents, desc="Upserting documents", unit="doc"):
             schema_manager.upsert_document(doc)
         print("Documents upserted successfully.")
+
+        # Process party entities
+        print("Processing party entities...")
+        process_party_entities(schema_manager)
+        print("Party entities processed successfully.")
 
     if "graph-clear" in args.actions:
         schema_manager = SchemaManager(

--- a/knowledge-base/model/__init__.py
+++ b/knowledge-base/model/__init__.py
@@ -3,6 +3,8 @@ from typing import Any
 import numpy as np
 from pydantic import BaseModel, field_serializer, field_validator, model_validator
 
+from .political_entities import Party as Party
+
 
 class Topic(BaseModel):
     id: int

--- a/knowledge-base/model/__init__.py
+++ b/knowledge-base/model/__init__.py
@@ -43,11 +43,13 @@ class DocumentSegment(BaseModel):
 
     model_config = {"arbitrary_types_allowed": True}
 
-    @model_validator(mode='after')
-    def validate_indices(self) -> 'DocumentSegment':
+    @model_validator(mode="after")
+    def validate_indices(self) -> "DocumentSegment":
         """Validate that start_index < end_index and page > 0."""
         if self.start_index >= self.end_index:
-            raise ValueError(f"start_index ({self.start_index}) must be less than end_index ({self.end_index})")
+            raise ValueError(
+                f"start_index ({self.start_index}) must be less than end_index ({self.end_index})"
+            )
         if self.page <= 0:
             raise ValueError(f"page ({self.page}) must be positive")
         if not self.text.strip():

--- a/knowledge-base/model/political_entities.py
+++ b/knowledge-base/model/political_entities.py
@@ -1,12 +1,25 @@
 
 import numpy as np
-from pydantic import BaseModel
+from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class Party(BaseModel):
+    model_config = ConfigDict(arbitrary_types_allowed=True)
+    
     abbreviation: str  # Primary key (C, M, S, SD, etc.)
     full_name: str  # Full party name from parties.json
     embedding: np.ndarray | None = None  # Future: aggregated position embedding
 
-    class Config:
-        arbitrary_types_allowed = True
+    @field_validator('abbreviation')
+    @classmethod
+    def validate_abbreviation(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError('abbreviation cannot be empty')
+        return v.strip()
+
+    @field_validator('full_name')
+    @classmethod
+    def validate_full_name(cls, v: str) -> str:
+        if not v or not v.strip():
+            raise ValueError('full_name cannot be empty')
+        return v.strip()

--- a/knowledge-base/model/political_entities.py
+++ b/knowledge-base/model/political_entities.py
@@ -1,0 +1,12 @@
+
+import numpy as np
+from pydantic import BaseModel
+
+
+class Party(BaseModel):
+    abbreviation: str  # Primary key (C, M, S, SD, etc.)
+    full_name: str  # Full party name from parties.json
+    embedding: np.ndarray | None = None  # Future: aggregated position embedding
+
+    class Config:
+        arbitrary_types_allowed = True

--- a/knowledge-base/model/political_entities.py
+++ b/knowledge-base/model/political_entities.py
@@ -1,25 +1,24 @@
-
 import numpy as np
 from pydantic import BaseModel, ConfigDict, field_validator
 
 
 class Party(BaseModel):
     model_config = ConfigDict(arbitrary_types_allowed=True)
-    
+
     abbreviation: str  # Primary key (C, M, S, SD, etc.)
     full_name: str  # Full party name from parties.json
     embedding: np.ndarray | None = None  # Future: aggregated position embedding
 
-    @field_validator('abbreviation')
+    @field_validator("abbreviation")
     @classmethod
     def validate_abbreviation(cls, v: str) -> str:
         if not v or not v.strip():
-            raise ValueError('abbreviation cannot be empty')
+            raise ValueError("abbreviation cannot be empty")
         return v.strip()
 
-    @field_validator('full_name')
+    @field_validator("full_name")
     @classmethod
     def validate_full_name(cls, v: str) -> str:
         if not v or not v.strip():
-            raise ValueError('full_name cannot be empty')
+            raise ValueError("full_name cannot be empty")
         return v.strip()

--- a/knowledge-base/tests/test_embedding.py
+++ b/knowledge-base/tests/test_embedding.py
@@ -84,7 +84,7 @@ async def test_get_embedding_success(embedding_client: EmbeddingClient):
         mock_client.embeddings.create = AsyncMock()
         mock_client.embeddings.create.side_effect = [
             AsyncMock(data=[AsyncMock(embedding=mock_embedding_1)]),
-            AsyncMock(data=[AsyncMock(embedding=mock_embedding_2)])
+            AsyncMock(data=[AsyncMock(embedding=mock_embedding_2)]),
         ]
 
         updated_documents_generator = embedding_client.embed_documents(documents)

--- a/knowledge-base/tests/test_integration_pipeline.py
+++ b/knowledge-base/tests/test_integration_pipeline.py
@@ -20,7 +20,7 @@ from analysis.embedding import EmbeddingClient
 from analysis.topic_modeling import extract_topics, topics_to_pydantic
 from graph import SchemaManager
 from main import process_party_entities
-from model import Document, DocumentSegment, Party, Topic
+from model import Document, DocumentSegment, Topic
 from parser import parse_document
 from util.errors import NoSuchDocumentError
 
@@ -438,11 +438,11 @@ class TestPartyIntegrationPipeline:
             "source": "Integration test data",
             "parties": {
                 "C": "Centerpartiet",
-                "M": "Moderaterna", 
-                "S": "Socialdemokraterna"
-            }
+                "M": "Moderaterna",
+                "S": "Socialdemokraterna",
+            },
         }
-        
+
         with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
             json.dump(parties_data, f)
             return Path(f.name)
@@ -455,158 +455,139 @@ class TestPartyIntegrationPipeline:
         mock_manager.link_documents_to_parties = MagicMock()
         return mock_manager
 
-    def test_party_processing_integration_success(self, mock_schema_manager_for_parties, mock_parties_json_file):
+    def test_party_processing_integration_success(
+        self, mock_schema_manager_for_parties, mock_parties_json_file
+    ):
         """Test complete party processing integration workflow."""
         # Read the actual JSON data from the temp file
-        with open(mock_parties_json_file, 'r') as f:
+        with open(mock_parties_json_file) as f:
             parties_data = json.load(f)
-        
+
         with patch("main.Path") as mock_path_class:
             # Mock the parties.json path to point to our test file
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = True
             mock_path_class.return_value = mock_parties_path
-            
+
             # Mock json.load to return our test data
             with patch("json.load", return_value=parties_data):
                 with patch("builtins.open", mock=MagicMock()):
                     # Execute the party processing
                     process_party_entities(mock_schema_manager_for_parties)
-            
+
             # Verify the complete workflow
             mock_schema_manager_for_parties.upsert_parties.assert_called_once()
             mock_schema_manager_for_parties.link_documents_to_parties.assert_called_once()
-            
+
             # Verify correct parties were processed
-            called_parties = mock_schema_manager_for_parties.upsert_parties.call_args[0][0]
+            called_parties = mock_schema_manager_for_parties.upsert_parties.call_args[
+                0
+            ][0]
             assert len(called_parties) == 3
-            
+
             party_names = {p.abbreviation: p.full_name for p in called_parties}
             assert party_names["C"] == "Centerpartiet"
             assert party_names["M"] == "Moderaterna"
             assert party_names["S"] == "Socialdemokraterna"
 
-    def test_party_processing_with_documents_integration(self, sample_documents, mock_schema_manager_for_parties):
+    def test_party_processing_with_documents_integration(
+        self, sample_documents, mock_schema_manager_for_parties
+    ):
         """Test integration of party processing with document processing."""
-        # Simulate documents that would be linked to parties
-        mock_documents = [
-            Document(
-                id="centerpartiet-doc",
-                path="knowledge-base/documents/centerpartiet/valmanifest.pdf",
-                raw_content="Centerpartiet policy content...",
-                segments=[
-                    DocumentSegment(
-                        id="c-seg-1",
-                        text="Rural development and sustainable agriculture.",
-                        start_index=0,
-                        end_index=43,
-                        page=1,
-                        metadata={},
-                        type="pdf",
-                    )
-                ],
-            ),
-            Document(
-                id="moderaterna-doc", 
-                path="knowledge-base/documents/moderaterna/ideprogram.pdf",
-                raw_content="Moderaterna ideology content...",
-                segments=[
-                    DocumentSegment(
-                        id="m-seg-1",
-                        text="Free market principles and individual responsibility.",
-                        start_index=0,
-                        end_index=51,
-                        page=1,
-                        metadata={},
-                        type="pdf",
-                    )
-                ],
-            ),
-        ]
-        
         # Mock the parties data
-        parties_data = {
-            "parties": {
-                "C": "Centerpartiet",
-                "M": "Moderaterna"
-            }
-        }
-        
+        parties_data = {"parties": {"C": "Centerpartiet", "M": "Moderaterna"}}
+
         with patch("main.Path") as mock_path_class:
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = True
             mock_path_class.return_value = mock_parties_path
-            
+
             with patch("json.load", return_value=parties_data):
                 with patch("builtins.open", mock=MagicMock()):
                     process_party_entities(mock_schema_manager_for_parties)
-        
+
         # Verify both parties and document linking were processed
         mock_schema_manager_for_parties.upsert_parties.assert_called_once()
         mock_schema_manager_for_parties.link_documents_to_parties.assert_called_once()
-        
+
         # Verify the parties were created correctly
         called_parties = mock_schema_manager_for_parties.upsert_parties.call_args[0][0]
         assert len(called_parties) == 2
-        assert any(p.abbreviation == "C" and p.full_name == "Centerpartiet" for p in called_parties)
-        assert any(p.abbreviation == "M" and p.full_name == "Moderaterna" for p in called_parties)
+        assert any(
+            p.abbreviation == "C" and p.full_name == "Centerpartiet"
+            for p in called_parties
+        )
+        assert any(
+            p.abbreviation == "M" and p.full_name == "Moderaterna"
+            for p in called_parties
+        )
 
-    def test_party_processing_error_handling_integration(self, mock_schema_manager_for_parties):
+    def test_party_processing_error_handling_integration(
+        self, mock_schema_manager_for_parties
+    ):
         """Test error handling in party processing integration."""
         # Test with missing parties.json file
         with patch("main.Path") as mock_path_class:
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = False
             mock_path_class.return_value = mock_parties_path
-            
-            # Should handle gracefully without crashing
-            process_party_entities(mock_schema_manager_for_parties)
-            
+
+            # Should raise FileNotFoundError
+            with pytest.raises(FileNotFoundError):
+                process_party_entities(mock_schema_manager_for_parties)
+
             # No database operations should occur
             mock_schema_manager_for_parties.upsert_parties.assert_not_called()
             mock_schema_manager_for_parties.link_documents_to_parties.assert_not_called()
 
-    def test_full_pipeline_with_parties_integration(self, sample_documents, mock_schema_manager_for_parties):
+    def test_full_pipeline_with_parties_integration(
+        self, sample_documents, mock_schema_manager_for_parties
+    ):
         """Test party processing as part of the complete pipeline workflow."""
         # Simulate the full pipeline: documents → embeddings → topics → graph (including parties)
-        
+
         # Mock embeddings for documents - just need to mock the client
         mock_embedding_client = AsyncMock(spec=EmbeddingClient)
-        
+
         # Mock topic modeling
         mock_topics = [
             Topic(
                 id=0,
                 name="Environmental Policy",
-                description="Topics related to environment and sustainability"
+                description="Topics related to environment and sustainability",
             ),
             Topic(
                 id=1,
-                name="Economic Policy", 
-                description="Topics related to economics and business"
-            )
+                name="Economic Policy",
+                description="Topics related to economics and business",
+            ),
         ]
-        
+
         # Mock parties data
         parties_data = {"parties": {"C": "Centerpartiet", "S": "Socialdemokraterna"}}
-        
-        with patch("analysis.embedding.EmbeddingClient", return_value=mock_embedding_client):
+
+        with patch(
+            "analysis.embedding.EmbeddingClient", return_value=mock_embedding_client
+        ):
             with patch("analysis.topic_modeling.extract_topics", return_value=([], [])):
-                with patch("analysis.topic_modeling.topics_to_pydantic", return_value=mock_topics):
+                with patch(
+                    "analysis.topic_modeling.topics_to_pydantic",
+                    return_value=mock_topics,
+                ):
                     with patch("main.Path") as mock_path_class:
                         mock_parties_path = MagicMock()
                         mock_parties_path.exists.return_value = True
                         mock_path_class.return_value = mock_parties_path
-                        
+
                         with patch("json.load", return_value=parties_data):
                             with patch("builtins.open", mock=MagicMock()):
                                 # This would be called as part of the main pipeline
                                 process_party_entities(mock_schema_manager_for_parties)
-        
+
         # Verify party processing completed successfully
         mock_schema_manager_for_parties.upsert_parties.assert_called_once()
         mock_schema_manager_for_parties.link_documents_to_parties.assert_called_once()
-        
+
         # Verify correct number of parties processed
         called_parties = mock_schema_manager_for_parties.upsert_parties.call_args[0][0]
         assert len(called_parties) == 2

--- a/knowledge-base/tests/test_party_processing.py
+++ b/knowledge-base/tests/test_party_processing.py
@@ -1,0 +1,189 @@
+"""
+Tests for party processing functionality in main.py
+"""
+
+import json
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
+
+import pytest
+
+from graph import SchemaManager
+from main import process_party_entities
+from model.political_entities import Party
+
+
+@pytest.fixture
+def mock_schema_manager():
+    """Create a mock SchemaManager for testing."""
+    mock_manager = MagicMock(spec=SchemaManager)
+    return mock_manager
+
+
+@pytest.fixture
+def sample_parties_json():
+    """Create a temporary parties.json file for testing."""
+    parties_data = {
+        "description": "Test parties mapping",
+        "extractedAt": "2025-01-01T00:00:00.000Z",
+        "totalParties": 4,
+        "source": "Test data",
+        "parties": {
+            "C": "Centerpartiet",
+            "M": "Moderaterna",
+            "S": "Socialdemokraterna",
+            "-": "Partilös",  # Should be skipped
+            "SD": "Sverigedemokraterna"
+        }
+    }
+    
+    with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
+        json.dump(parties_data, f)
+        return Path(f.name)
+
+
+class TestProcessPartyEntities:
+    """Tests for the process_party_entities function."""
+
+    def test_process_party_entities_success(self, mock_schema_manager, sample_parties_json):
+        """Test successful processing of party entities."""
+        # Read the actual JSON data from the temp file
+        with open(sample_parties_json, 'r') as f:
+            parties_data = json.load(f)
+        
+        with patch("main.Path") as mock_path_class:
+            # Mock the parties.json path
+            mock_parties_path = MagicMock()
+            mock_parties_path.exists.return_value = True
+            mock_path_class.return_value = mock_parties_path
+            
+            # Mock json.load to return our test data
+            with patch("json.load", return_value=parties_data):
+                with patch("builtins.open", mock=MagicMock()):
+                    process_party_entities(mock_schema_manager)
+            
+            # Verify that upsert_parties was called
+            mock_schema_manager.upsert_parties.assert_called_once()
+            
+            # Verify that link_documents_to_parties was called
+            mock_schema_manager.link_documents_to_parties.assert_called_once()
+            
+            # Check the parties that were passed to upsert_parties
+            called_parties = mock_schema_manager.upsert_parties.call_args[0][0]
+            assert len(called_parties) == 4  # Should exclude "Partilös" (-)
+            
+            # Verify specific parties
+            party_abbrevs = [p.abbreviation for p in called_parties]
+            assert "C" in party_abbrevs
+            assert "M" in party_abbrevs
+            assert "S" in party_abbrevs
+            assert "SD" in party_abbrevs
+            assert "-" not in party_abbrevs  # Should be excluded
+
+    def test_process_party_entities_file_not_found(self, mock_schema_manager, caplog):
+        """Test behavior when parties.json file is not found."""
+        with patch("main.Path") as mock_path_class:
+            mock_parties_path = MagicMock()
+            mock_parties_path.exists.return_value = False
+            mock_path_class.return_value = mock_parties_path
+            
+            process_party_entities(mock_schema_manager)
+            
+            # Verify no database operations were performed
+            mock_schema_manager.upsert_parties.assert_not_called()
+            mock_schema_manager.link_documents_to_parties.assert_not_called()
+            
+            # Check that error was logged
+            assert "Parties file not found" in caplog.text
+
+    def test_process_party_entities_creates_correct_party_objects(self, mock_schema_manager, sample_parties_json):
+        """Test that correct Party objects are created from JSON data."""
+        # Read the actual JSON data from the temp file
+        with open(sample_parties_json, 'r') as f:
+            parties_data = json.load(f)
+        
+        with patch("main.Path") as mock_path_class:
+            mock_parties_path = MagicMock()
+            mock_parties_path.exists.return_value = True
+            mock_path_class.return_value = mock_parties_path
+            
+            with patch("json.load", return_value=parties_data):
+                with patch("builtins.open", mock=MagicMock()):
+                    process_party_entities(mock_schema_manager)
+            
+            called_parties = mock_schema_manager.upsert_parties.call_args[0][0]
+            
+            # Find specific party and verify attributes
+            centerpartiet = next(p for p in called_parties if p.abbreviation == "C")
+            assert centerpartiet.full_name == "Centerpartiet"
+            assert centerpartiet.embedding is None
+            
+            moderaterna = next(p for p in called_parties if p.abbreviation == "M")
+            assert moderaterna.full_name == "Moderaterna"
+
+    def test_process_party_entities_empty_parties_dict(self, mock_schema_manager):
+        """Test behavior with empty parties dictionary."""
+        empty_parties_data = {
+            "description": "Empty parties",
+            "parties": {}
+        }
+        
+        with patch("main.Path") as mock_path_class:
+            mock_parties_path = MagicMock()
+            mock_parties_path.exists.return_value = True
+            mock_path_class.return_value = mock_parties_path
+            
+            with patch("builtins.open", mock=MagicMock()) as mock_open:
+                mock_file = MagicMock()
+                mock_file.read.return_value = json.dumps(empty_parties_data)
+                mock_open.return_value.__enter__.return_value = mock_file
+                
+                with patch("json.load", return_value=empty_parties_data):
+                    process_party_entities(mock_schema_manager)
+            
+            # Should still call upsert_parties with empty list
+            mock_schema_manager.upsert_parties.assert_called_once_with([])
+            mock_schema_manager.link_documents_to_parties.assert_called_once()
+
+    def test_process_party_entities_malformed_json(self, mock_schema_manager, caplog):
+        """Test behavior with malformed JSON file."""
+        with patch("main.Path") as mock_path_class:
+            mock_parties_path = MagicMock()
+            mock_parties_path.exists.return_value = True
+            mock_path_class.return_value = mock_parties_path
+            
+            with patch("builtins.open", mock=MagicMock()) as mock_open:
+                mock_file = MagicMock()
+                mock_file.read.return_value = "invalid json"
+                mock_open.return_value.__enter__.return_value = mock_file
+                
+                with patch("json.load", side_effect=json.JSONDecodeError("Invalid JSON", "", 0)):
+                    # Should let the exception propagate (fail-fast principle)
+                    with pytest.raises(json.JSONDecodeError):
+                        process_party_entities(mock_schema_manager)
+            
+            # No database operations should have been performed
+            mock_schema_manager.upsert_parties.assert_not_called()
+            mock_schema_manager.link_documents_to_parties.assert_not_called()
+
+    @patch("main.logger")
+    def test_process_party_entities_logging(self, mock_logger, mock_schema_manager, sample_parties_json):
+        """Test that appropriate log messages are generated."""
+        # Read the actual JSON data from the temp file
+        with open(sample_parties_json, 'r') as f:
+            parties_data = json.load(f)
+        
+        with patch("main.Path") as mock_path_class:
+            mock_parties_path = MagicMock()
+            mock_parties_path.exists.return_value = True
+            mock_path_class.return_value = mock_parties_path
+            
+            with patch("json.load", return_value=parties_data):
+                with patch("builtins.open", mock=MagicMock()):
+                    process_party_entities(mock_schema_manager)
+            
+            # Verify logging calls
+            mock_logger.info.assert_any_call("Processing party entities...")
+            mock_logger.info.assert_any_call("Created 4 party nodes")
+            mock_logger.info.assert_any_call("Linked parties to their authored documents")

--- a/knowledge-base/tests/test_party_processing.py
+++ b/knowledge-base/tests/test_party_processing.py
@@ -11,7 +11,6 @@ import pytest
 
 from graph import SchemaManager
 from main import process_party_entities
-from model.political_entities import Party
 
 
 @pytest.fixture
@@ -34,10 +33,10 @@ def sample_parties_json():
             "M": "Moderaterna",
             "S": "Socialdemokraterna",
             "-": "Partilös",  # Should be skipped
-            "SD": "Sverigedemokraterna"
-        }
+            "SD": "Sverigedemokraterna",
+        },
     }
-    
+
     with tempfile.NamedTemporaryFile(mode="w", suffix=".json", delete=False) as f:
         json.dump(parties_data, f)
         return Path(f.name)
@@ -46,33 +45,35 @@ def sample_parties_json():
 class TestProcessPartyEntities:
     """Tests for the process_party_entities function."""
 
-    def test_process_party_entities_success(self, mock_schema_manager, sample_parties_json):
+    def test_process_party_entities_success(
+        self, mock_schema_manager, sample_parties_json
+    ):
         """Test successful processing of party entities."""
         # Read the actual JSON data from the temp file
-        with open(sample_parties_json, 'r') as f:
+        with open(sample_parties_json) as f:
             parties_data = json.load(f)
-        
+
         with patch("main.Path") as mock_path_class:
             # Mock the parties.json path
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = True
             mock_path_class.return_value = mock_parties_path
-            
+
             # Mock json.load to return our test data
             with patch("json.load", return_value=parties_data):
                 with patch("builtins.open", mock=MagicMock()):
                     process_party_entities(mock_schema_manager)
-            
+
             # Verify that upsert_parties was called
             mock_schema_manager.upsert_parties.assert_called_once()
-            
+
             # Verify that link_documents_to_parties was called
             mock_schema_manager.link_documents_to_parties.assert_called_once()
-            
+
             # Check the parties that were passed to upsert_parties
             called_parties = mock_schema_manager.upsert_parties.call_args[0][0]
             assert len(called_parties) == 4  # Should exclude "Partilös" (-)
-            
+
             # Verify specific parties
             party_abbrevs = [p.abbreviation for p in called_parties]
             assert "C" in party_abbrevs
@@ -87,61 +88,61 @@ class TestProcessPartyEntities:
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = False
             mock_path_class.return_value = mock_parties_path
-            
-            process_party_entities(mock_schema_manager)
-            
+
+            with pytest.raises(FileNotFoundError):
+                process_party_entities(mock_schema_manager)
+
             # Verify no database operations were performed
             mock_schema_manager.upsert_parties.assert_not_called()
             mock_schema_manager.link_documents_to_parties.assert_not_called()
-            
+
             # Check that error was logged
             assert "Parties file not found" in caplog.text
 
-    def test_process_party_entities_creates_correct_party_objects(self, mock_schema_manager, sample_parties_json):
+    def test_process_party_entities_creates_correct_party_objects(
+        self, mock_schema_manager, sample_parties_json
+    ):
         """Test that correct Party objects are created from JSON data."""
         # Read the actual JSON data from the temp file
-        with open(sample_parties_json, 'r') as f:
+        with open(sample_parties_json) as f:
             parties_data = json.load(f)
-        
+
         with patch("main.Path") as mock_path_class:
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = True
             mock_path_class.return_value = mock_parties_path
-            
+
             with patch("json.load", return_value=parties_data):
                 with patch("builtins.open", mock=MagicMock()):
                     process_party_entities(mock_schema_manager)
-            
+
             called_parties = mock_schema_manager.upsert_parties.call_args[0][0]
-            
+
             # Find specific party and verify attributes
             centerpartiet = next(p for p in called_parties if p.abbreviation == "C")
             assert centerpartiet.full_name == "Centerpartiet"
             assert centerpartiet.embedding is None
-            
+
             moderaterna = next(p for p in called_parties if p.abbreviation == "M")
             assert moderaterna.full_name == "Moderaterna"
 
     def test_process_party_entities_empty_parties_dict(self, mock_schema_manager):
         """Test behavior with empty parties dictionary."""
-        empty_parties_data = {
-            "description": "Empty parties",
-            "parties": {}
-        }
-        
+        empty_parties_data = {"description": "Empty parties", "parties": {}}
+
         with patch("main.Path") as mock_path_class:
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = True
             mock_path_class.return_value = mock_parties_path
-            
+
             with patch("builtins.open", mock=MagicMock()) as mock_open:
                 mock_file = MagicMock()
                 mock_file.read.return_value = json.dumps(empty_parties_data)
                 mock_open.return_value.__enter__.return_value = mock_file
-                
+
                 with patch("json.load", return_value=empty_parties_data):
                     process_party_entities(mock_schema_manager)
-            
+
             # Should still call upsert_parties with empty list
             mock_schema_manager.upsert_parties.assert_called_once_with([])
             mock_schema_manager.link_documents_to_parties.assert_called_once()
@@ -152,38 +153,44 @@ class TestProcessPartyEntities:
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = True
             mock_path_class.return_value = mock_parties_path
-            
+
             with patch("builtins.open", mock=MagicMock()) as mock_open:
                 mock_file = MagicMock()
                 mock_file.read.return_value = "invalid json"
                 mock_open.return_value.__enter__.return_value = mock_file
-                
-                with patch("json.load", side_effect=json.JSONDecodeError("Invalid JSON", "", 0)):
+
+                with patch(
+                    "json.load", side_effect=json.JSONDecodeError("Invalid JSON", "", 0)
+                ):
                     # Should let the exception propagate (fail-fast principle)
                     with pytest.raises(json.JSONDecodeError):
                         process_party_entities(mock_schema_manager)
-            
+
             # No database operations should have been performed
             mock_schema_manager.upsert_parties.assert_not_called()
             mock_schema_manager.link_documents_to_parties.assert_not_called()
 
     @patch("main.logger")
-    def test_process_party_entities_logging(self, mock_logger, mock_schema_manager, sample_parties_json):
+    def test_process_party_entities_logging(
+        self, mock_logger, mock_schema_manager, sample_parties_json
+    ):
         """Test that appropriate log messages are generated."""
         # Read the actual JSON data from the temp file
-        with open(sample_parties_json, 'r') as f:
+        with open(sample_parties_json) as f:
             parties_data = json.load(f)
-        
+
         with patch("main.Path") as mock_path_class:
             mock_parties_path = MagicMock()
             mock_parties_path.exists.return_value = True
             mock_path_class.return_value = mock_parties_path
-            
+
             with patch("json.load", return_value=parties_data):
                 with patch("builtins.open", mock=MagicMock()):
                     process_party_entities(mock_schema_manager)
-            
+
             # Verify logging calls
             mock_logger.info.assert_any_call("Processing party entities...")
             mock_logger.info.assert_any_call("Created 4 party nodes")
-            mock_logger.info.assert_any_call("Linked parties to their authored documents")
+            mock_logger.info.assert_any_call(
+                "Linked parties to their authored documents"
+            )

--- a/knowledge-base/tests/test_pdf_parser_integration.py
+++ b/knowledge-base/tests/test_pdf_parser_integration.py
@@ -99,9 +99,7 @@ def test_parse_pdf_basic_processing(sample_pdf_path):
         assert isinstance(segment.id, str), (
             f"Segment {i} id attribute is not a string: {segment.id}"
         )
-        assert len(segment.id) > 0, (
-            f"Segment {i} id attribute should not be empty"
-        )
+        assert len(segment.id) > 0, f"Segment {i} id attribute should not be empty"
 
 
 def test_parse_pdf_non_existent_file():

--- a/knowledge-base/tests/test_political_entities.py
+++ b/knowledge-base/tests/test_political_entities.py
@@ -1,0 +1,103 @@
+"""
+Tests for the Party model in political_entities.py
+"""
+
+import numpy as np
+import pytest
+
+from model.political_entities import Party
+
+
+class TestParty:
+    """Tests for the Party model."""
+
+    def test_party_creation_basic(self):
+        """Test creating a Party with required fields."""
+        party = Party(
+            abbreviation="S",
+            full_name="Socialdemokraterna"
+        )
+        
+        assert party.abbreviation == "S"
+        assert party.full_name == "Socialdemokraterna"
+        assert party.embedding is None
+
+    def test_party_creation_with_embedding(self):
+        """Test creating a Party with an embedding."""
+        embedding = np.array([0.1, 0.2, 0.3])
+        party = Party(
+            abbreviation="M",
+            full_name="Moderaterna",
+            embedding=embedding
+        )
+        
+        assert party.abbreviation == "M"
+        assert party.full_name == "Moderaterna"
+        assert np.array_equal(party.embedding, embedding)
+
+    def test_party_validation_empty_abbreviation(self):
+        """Test that empty abbreviation is not allowed."""
+        with pytest.raises(ValueError):
+            Party(
+                abbreviation="",
+                full_name="Socialdemokraterna"
+            )
+
+    def test_party_validation_empty_full_name(self):
+        """Test that empty full_name is not allowed."""
+        with pytest.raises(ValueError):
+            Party(
+                abbreviation="S",
+                full_name=""
+            )
+
+    def test_party_equality(self):
+        """Test Party equality comparison."""
+        party1 = Party(abbreviation="C", full_name="Centerpartiet")
+        party2 = Party(abbreviation="C", full_name="Centerpartiet")
+        party3 = Party(abbreviation="M", full_name="Moderaterna")
+        
+        assert party1 == party2
+        assert party1 != party3
+
+    def test_party_repr(self):
+        """Test Party string representation."""
+        party = Party(abbreviation="V", full_name="Vänsterpartiet")
+        repr_str = repr(party)
+        
+        assert "V" in repr_str
+        assert "Vänsterpartiet" in repr_str
+
+    def test_party_with_none_embedding(self):
+        """Test that None embedding is handled correctly."""
+        party = Party(
+            abbreviation="KD",
+            full_name="Kristdemokraterna",
+            embedding=None
+        )
+        
+        assert party.embedding is None
+
+    def test_party_with_large_embedding(self):
+        """Test Party with a realistic-sized embedding (1536 dimensions like OpenAI)."""
+        embedding = np.random.rand(1536)
+        party = Party(
+            abbreviation="MP",
+            full_name="Miljöpartiet de gröna",
+            embedding=embedding
+        )
+        
+        assert party.embedding.shape == (1536,)
+        assert np.array_equal(party.embedding, embedding)
+
+    def test_party_config_arbitrary_types(self):
+        """Test that the arbitrary_types_allowed config works for numpy arrays."""
+        # This should not raise an error due to the Config class
+        embedding = np.array([1.0, 2.0, 3.0])
+        party = Party(
+            abbreviation="SD",
+            full_name="Sverigedemokraterna",
+            embedding=embedding
+        )
+        
+        assert isinstance(party.embedding, np.ndarray)

--- a/knowledge-base/tests/test_political_entities.py
+++ b/knowledge-base/tests/test_political_entities.py
@@ -13,11 +13,8 @@ class TestParty:
 
     def test_party_creation_basic(self):
         """Test creating a Party with required fields."""
-        party = Party(
-            abbreviation="S",
-            full_name="Socialdemokraterna"
-        )
-        
+        party = Party(abbreviation="S", full_name="Socialdemokraterna")
+
         assert party.abbreviation == "S"
         assert party.full_name == "Socialdemokraterna"
         assert party.embedding is None
@@ -25,12 +22,8 @@ class TestParty:
     def test_party_creation_with_embedding(self):
         """Test creating a Party with an embedding."""
         embedding = np.array([0.1, 0.2, 0.3])
-        party = Party(
-            abbreviation="M",
-            full_name="Moderaterna",
-            embedding=embedding
-        )
-        
+        party = Party(abbreviation="M", full_name="Moderaterna", embedding=embedding)
+
         assert party.abbreviation == "M"
         assert party.full_name == "Moderaterna"
         assert np.array_equal(party.embedding, embedding)
@@ -38,25 +31,19 @@ class TestParty:
     def test_party_validation_empty_abbreviation(self):
         """Test that empty abbreviation is not allowed."""
         with pytest.raises(ValueError):
-            Party(
-                abbreviation="",
-                full_name="Socialdemokraterna"
-            )
+            Party(abbreviation="", full_name="Socialdemokraterna")
 
     def test_party_validation_empty_full_name(self):
         """Test that empty full_name is not allowed."""
         with pytest.raises(ValueError):
-            Party(
-                abbreviation="S",
-                full_name=""
-            )
+            Party(abbreviation="S", full_name="")
 
     def test_party_equality(self):
         """Test Party equality comparison."""
         party1 = Party(abbreviation="C", full_name="Centerpartiet")
         party2 = Party(abbreviation="C", full_name="Centerpartiet")
         party3 = Party(abbreviation="M", full_name="Moderaterna")
-        
+
         assert party1 == party2
         assert party1 != party3
 
@@ -64,29 +51,23 @@ class TestParty:
         """Test Party string representation."""
         party = Party(abbreviation="V", full_name="Vänsterpartiet")
         repr_str = repr(party)
-        
+
         assert "V" in repr_str
         assert "Vänsterpartiet" in repr_str
 
     def test_party_with_none_embedding(self):
         """Test that None embedding is handled correctly."""
-        party = Party(
-            abbreviation="KD",
-            full_name="Kristdemokraterna",
-            embedding=None
-        )
-        
+        party = Party(abbreviation="KD", full_name="Kristdemokraterna", embedding=None)
+
         assert party.embedding is None
 
     def test_party_with_large_embedding(self):
         """Test Party with a realistic-sized embedding (1536 dimensions like OpenAI)."""
         embedding = np.random.rand(1536)
         party = Party(
-            abbreviation="MP",
-            full_name="Miljöpartiet de gröna",
-            embedding=embedding
+            abbreviation="MP", full_name="Miljöpartiet de gröna", embedding=embedding
         )
-        
+
         assert party.embedding.shape == (1536,)
         assert np.array_equal(party.embedding, embedding)
 
@@ -95,9 +76,7 @@ class TestParty:
         # This should not raise an error due to the Config class
         embedding = np.array([1.0, 2.0, 3.0])
         party = Party(
-            abbreviation="SD",
-            full_name="Sverigedemokraterna",
-            embedding=embedding
+            abbreviation="SD", full_name="Sverigedemokraterna", embedding=embedding
         )
-        
+
         assert isinstance(party.embedding, np.ndarray)

--- a/knowledge-base/tests/test_schema_manager_parties.py
+++ b/knowledge-base/tests/test_schema_manager_parties.py
@@ -1,0 +1,231 @@
+"""
+Tests for party-related methods in SchemaManager
+"""
+
+from unittest.mock import MagicMock, call, patch
+
+import pytest
+
+from graph import SchemaManager
+from model.political_entities import Party
+
+
+@pytest.fixture
+def mock_driver():
+    """Create a mock Neo4j driver."""
+    return MagicMock()
+
+
+@pytest.fixture
+def mock_session():
+    """Create a mock Neo4j session."""
+    return MagicMock()
+
+
+@pytest.fixture
+def schema_manager(mock_driver):
+    """Create a SchemaManager with mocked driver."""
+    with patch.object(SchemaManager, '__init__', lambda self, uri, user, password: None):
+        manager = SchemaManager.__new__(SchemaManager)
+        manager.driver = mock_driver
+        return manager
+
+
+@pytest.fixture
+def sample_parties():
+    """Create sample Party objects for testing."""
+    return [
+        Party(abbreviation="C", full_name="Centerpartiet"),
+        Party(abbreviation="M", full_name="Moderaterna"),
+        Party(abbreviation="S", full_name="Socialdemokraterna")
+    ]
+
+
+class TestSchemaManagerParties:
+    """Tests for party-related methods in SchemaManager."""
+
+    def test_upsert_party_success(self, schema_manager, mock_session):
+        """Test successful insertion of a single party."""
+        party = Party(abbreviation="V", full_name="Vänsterpartiet")
+        
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        schema_manager.upsert_party(party)
+        
+        # Verify session was used correctly
+        schema_manager.driver.session.assert_called_once()
+        
+        # Verify the correct Cypher query was executed
+        mock_session.run.assert_called_once()
+        call_args = mock_session.run.call_args
+        
+        # Check the query structure
+        query = call_args[0][0]
+        assert "MERGE (p:Party {abbreviation: $abbreviation})" in query
+        assert "SET p.full_name = $full_name" in query
+        
+        # Check the parameters
+        params = call_args[1]
+        assert params["abbreviation"] == "V"
+        assert params["full_name"] == "Vänsterpartiet"
+
+    def test_upsert_parties_bulk_success(self, schema_manager, mock_session, sample_parties):
+        """Test successful bulk insertion of multiple parties."""
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        schema_manager.upsert_parties(sample_parties)
+        
+        # Verify session was used correctly
+        schema_manager.driver.session.assert_called_once()
+        
+        # Verify the correct Cypher query was executed
+        mock_session.run.assert_called_once()
+        call_args = mock_session.run.call_args
+        
+        # Check the query structure
+        query = call_args[0][0]
+        assert "UNWIND $parties AS party" in query
+        assert "MERGE (p:Party {abbreviation: party.abbreviation})" in query
+        assert "SET p.full_name = party.full_name" in query
+        
+        # Check the parameters - should be a list of party data
+        params = call_args[1]
+        parties_data = params["parties"]
+        assert len(parties_data) == 3
+        
+        # Verify specific party data
+        party_abbrevs = [p["abbreviation"] for p in parties_data]
+        assert "C" in party_abbrevs
+        assert "M" in party_abbrevs
+        assert "S" in party_abbrevs
+        
+        centerpartiet_data = next(p for p in parties_data if p["abbreviation"] == "C")
+        assert centerpartiet_data["full_name"] == "Centerpartiet"
+
+    def test_upsert_parties_empty_list(self, schema_manager, mock_session):
+        """Test bulk upsert with empty list."""
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        schema_manager.upsert_parties([])
+        
+        # Should still execute the query with empty data
+        schema_manager.driver.session.assert_called_once()
+        mock_session.run.assert_called_once()
+        
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        assert params["parties"] == []
+
+    def test_link_documents_to_parties_success(self, schema_manager, mock_session):
+        """Test successful linking of documents to parties."""
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        schema_manager.link_documents_to_parties()
+        
+        # Verify session was used correctly
+        schema_manager.driver.session.assert_called_once()
+        
+        # Should make multiple calls - one for each party mapping
+        expected_folder_mappings = {
+            "centerpartiet": "C",
+            "liberalerna": "L",
+            "miljopartiet": "MP",
+            "moderaterna": "M",
+            "socialdemokraterna": "S",
+            "sverigedemokraterna": "SD",
+            "vansterpartiet": "V",
+            "kristdemokraterna": "KD"
+        }
+        
+        # Verify the number of calls matches the number of mappings
+        assert mock_session.run.call_count == len(expected_folder_mappings)
+        
+        # Verify each mapping was processed
+        all_calls = mock_session.run.call_args_list
+        
+        for call_obj in all_calls:
+            query = call_obj[0][0]
+            params = call_obj[1]
+            
+            # Check query structure
+            assert "MATCH (d:Document)" in query
+            assert "WHERE d.path CONTAINS $folder_pattern" in query
+            assert "MATCH (p:Party {abbreviation: $party_abbr})" in query
+            assert "MERGE (p)-[:AUTHORED]->(d)" in query
+            
+            # Verify folder pattern format
+            folder_pattern = params["folder_pattern"]
+            party_abbr = params["party_abbr"]
+            
+            assert folder_pattern.startswith("/documents/")
+            assert folder_pattern.endswith("/")
+            assert party_abbr in expected_folder_mappings.values()
+
+    def test_link_documents_to_parties_specific_mappings(self, schema_manager, mock_session):
+        """Test that specific folder-to-party mappings are correct."""
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        schema_manager.link_documents_to_parties()
+        
+        # Extract all the parameters used in the calls
+        all_calls = mock_session.run.call_args_list
+        call_params = [call_obj[1] for call_obj in all_calls]
+        
+        # Verify specific mappings
+        centerpartiet_call = next(
+            params for params in call_params 
+            if params["party_abbr"] == "C"
+        )
+        assert centerpartiet_call["folder_pattern"] == "/documents/centerpartiet/"
+        
+        moderaterna_call = next(
+            params for params in call_params 
+            if params["party_abbr"] == "M"
+        )
+        assert moderaterna_call["folder_pattern"] == "/documents/moderaterna/"
+        
+        miljopartiet_call = next(
+            params for params in call_params 
+            if params["party_abbr"] == "MP"
+        )
+        assert miljopartiet_call["folder_pattern"] == "/documents/miljopartiet/"
+
+    def test_upsert_party_special_characters(self, schema_manager, mock_session):
+        """Test party with special characters in name."""
+        party = Party(abbreviation="MP", full_name="Miljöpartiet de gröna")
+        
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        schema_manager.upsert_party(party)
+        
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        assert params["full_name"] == "Miljöpartiet de gröna"
+
+    def test_schema_manager_driver_error_handling(self, schema_manager, mock_session):
+        """Test that database errors are properly propagated."""
+        party = Party(abbreviation="KD", full_name="Kristdemokraterna")
+        
+        # Mock a database error
+        mock_session.run.side_effect = Exception("Database connection failed")
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        # Should let the exception propagate (fail-fast principle)
+        with pytest.raises(Exception, match="Database connection failed"):
+            schema_manager.upsert_party(party)
+
+    def test_upsert_parties_single_party_in_list(self, schema_manager, mock_session):
+        """Test bulk upsert with single party in list."""
+        party = Party(abbreviation="FP", full_name="Folkpartiet liberalerna")
+        
+        schema_manager.driver.session.return_value.__enter__.return_value = mock_session
+        
+        schema_manager.upsert_parties([party])
+        
+        call_args = mock_session.run.call_args
+        params = call_args[1]
+        parties_data = params["parties"]
+        
+        assert len(parties_data) == 1
+        assert parties_data[0]["abbreviation"] == "FP"
+        assert parties_data[0]["full_name"] == "Folkpartiet liberalerna"

--- a/knowledge-base/tests/test_schema_manager_parties.py
+++ b/knowledge-base/tests/test_schema_manager_parties.py
@@ -2,7 +2,7 @@
 Tests for party-related methods in SchemaManager
 """
 
-from unittest.mock import MagicMock, call, patch
+from unittest.mock import MagicMock, patch
 
 import pytest
 
@@ -25,7 +25,9 @@ def mock_session():
 @pytest.fixture
 def schema_manager(mock_driver):
     """Create a SchemaManager with mocked driver."""
-    with patch.object(SchemaManager, '__init__', lambda self, uri, user, password: None):
+    with patch.object(
+        SchemaManager, "__init__", lambda self, uri, user, password: None
+    ):
         manager = SchemaManager.__new__(SchemaManager)
         manager.driver = mock_driver
         return manager
@@ -37,7 +39,7 @@ def sample_parties():
     return [
         Party(abbreviation="C", full_name="Centerpartiet"),
         Party(abbreviation="M", full_name="Moderaterna"),
-        Party(abbreviation="S", full_name="Socialdemokraterna")
+        Party(abbreviation="S", full_name="Socialdemokraterna"),
     ]
 
 
@@ -47,71 +49,73 @@ class TestSchemaManagerParties:
     def test_upsert_party_success(self, schema_manager, mock_session):
         """Test successful insertion of a single party."""
         party = Party(abbreviation="V", full_name="Vänsterpartiet")
-        
+
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         schema_manager.upsert_party(party)
-        
+
         # Verify session was used correctly
         schema_manager.driver.session.assert_called_once()
-        
+
         # Verify the correct Cypher query was executed
         mock_session.run.assert_called_once()
         call_args = mock_session.run.call_args
-        
+
         # Check the query structure
         query = call_args[0][0]
         assert "MERGE (p:Party {abbreviation: $abbreviation})" in query
         assert "SET p.full_name = $full_name" in query
-        
+
         # Check the parameters
         params = call_args[1]
         assert params["abbreviation"] == "V"
         assert params["full_name"] == "Vänsterpartiet"
 
-    def test_upsert_parties_bulk_success(self, schema_manager, mock_session, sample_parties):
+    def test_upsert_parties_bulk_success(
+        self, schema_manager, mock_session, sample_parties
+    ):
         """Test successful bulk insertion of multiple parties."""
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         schema_manager.upsert_parties(sample_parties)
-        
+
         # Verify session was used correctly
         schema_manager.driver.session.assert_called_once()
-        
+
         # Verify the correct Cypher query was executed
         mock_session.run.assert_called_once()
         call_args = mock_session.run.call_args
-        
+
         # Check the query structure
         query = call_args[0][0]
         assert "UNWIND $parties AS party" in query
         assert "MERGE (p:Party {abbreviation: party.abbreviation})" in query
         assert "SET p.full_name = party.full_name" in query
-        
+
         # Check the parameters - should be a list of party data
         params = call_args[1]
         parties_data = params["parties"]
         assert len(parties_data) == 3
-        
+
         # Verify specific party data
         party_abbrevs = [p["abbreviation"] for p in parties_data]
         assert "C" in party_abbrevs
         assert "M" in party_abbrevs
         assert "S" in party_abbrevs
-        
+
         centerpartiet_data = next(p for p in parties_data if p["abbreviation"] == "C")
         assert centerpartiet_data["full_name"] == "Centerpartiet"
 
     def test_upsert_parties_empty_list(self, schema_manager, mock_session):
         """Test bulk upsert with empty list."""
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         schema_manager.upsert_parties([])
-        
+
         # Should still execute the query with empty data
         schema_manager.driver.session.assert_called_once()
         mock_session.run.assert_called_once()
-        
+
         call_args = mock_session.run.call_args
         params = call_args[1]
         assert params["parties"] == []
@@ -119,12 +123,12 @@ class TestSchemaManagerParties:
     def test_link_documents_to_parties_success(self, schema_manager, mock_session):
         """Test successful linking of documents to parties."""
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         schema_manager.link_documents_to_parties()
-        
+
         # Verify session was used correctly
         schema_manager.driver.session.assert_called_once()
-        
+
         # Should make multiple calls - one for each party mapping
         expected_folder_mappings = {
             "centerpartiet": "C",
@@ -134,70 +138,69 @@ class TestSchemaManagerParties:
             "socialdemokraterna": "S",
             "sverigedemokraterna": "SD",
             "vansterpartiet": "V",
-            "kristdemokraterna": "KD"
+            "kristdemokraterna": "KD",
         }
-        
+
         # Verify the number of calls matches the number of mappings
         assert mock_session.run.call_count == len(expected_folder_mappings)
-        
+
         # Verify each mapping was processed
         all_calls = mock_session.run.call_args_list
-        
+
         for call_obj in all_calls:
             query = call_obj[0][0]
             params = call_obj[1]
-            
+
             # Check query structure
             assert "MATCH (d:Document)" in query
             assert "WHERE d.path CONTAINS $folder_pattern" in query
             assert "MATCH (p:Party {abbreviation: $party_abbr})" in query
             assert "MERGE (p)-[:AUTHORED]->(d)" in query
-            
+
             # Verify folder pattern format
             folder_pattern = params["folder_pattern"]
             party_abbr = params["party_abbr"]
-            
+
             assert folder_pattern.startswith("/documents/")
             assert folder_pattern.endswith("/")
             assert party_abbr in expected_folder_mappings.values()
 
-    def test_link_documents_to_parties_specific_mappings(self, schema_manager, mock_session):
+    def test_link_documents_to_parties_specific_mappings(
+        self, schema_manager, mock_session
+    ):
         """Test that specific folder-to-party mappings are correct."""
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         schema_manager.link_documents_to_parties()
-        
+
         # Extract all the parameters used in the calls
         all_calls = mock_session.run.call_args_list
         call_params = [call_obj[1] for call_obj in all_calls]
-        
+
         # Verify specific mappings
         centerpartiet_call = next(
-            params for params in call_params 
-            if params["party_abbr"] == "C"
+            params for params in call_params if params["party_abbr"] == "C"
         )
         assert centerpartiet_call["folder_pattern"] == "/documents/centerpartiet/"
-        
+
         moderaterna_call = next(
-            params for params in call_params 
-            if params["party_abbr"] == "M"
+            params for params in call_params if params["party_abbr"] == "M"
         )
         assert moderaterna_call["folder_pattern"] == "/documents/moderaterna/"
-        
+
         miljopartiet_call = next(
-            params for params in call_params 
-            if params["party_abbr"] == "MP"
+            params for params in call_params if params["party_abbr"] == "MP"
         )
         assert miljopartiet_call["folder_pattern"] == "/documents/miljopartiet/"
 
     def test_upsert_party_special_characters(self, schema_manager, mock_session):
         """Test party with special characters in name."""
         party = Party(abbreviation="MP", full_name="Miljöpartiet de gröna")
-        
+
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         schema_manager.upsert_party(party)
-        
+
         call_args = mock_session.run.call_args
         params = call_args[1]
         assert params["full_name"] == "Miljöpartiet de gröna"
@@ -205,11 +208,11 @@ class TestSchemaManagerParties:
     def test_schema_manager_driver_error_handling(self, schema_manager, mock_session):
         """Test that database errors are properly propagated."""
         party = Party(abbreviation="KD", full_name="Kristdemokraterna")
-        
+
         # Mock a database error
         mock_session.run.side_effect = Exception("Database connection failed")
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         # Should let the exception propagate (fail-fast principle)
         with pytest.raises(Exception, match="Database connection failed"):
             schema_manager.upsert_party(party)
@@ -217,15 +220,15 @@ class TestSchemaManagerParties:
     def test_upsert_parties_single_party_in_list(self, schema_manager, mock_session):
         """Test bulk upsert with single party in list."""
         party = Party(abbreviation="FP", full_name="Folkpartiet liberalerna")
-        
+
         schema_manager.driver.session.return_value.__enter__.return_value = mock_session
-        
+
         schema_manager.upsert_parties([party])
-        
+
         call_args = mock_session.run.call_args
         params = call_args[1]
         parties_data = params["parties"]
-        
+
         assert len(parties_data) == 1
         assert parties_data[0]["abbreviation"] == "FP"
         assert parties_data[0]["full_name"] == "Folkpartiet liberalerna"


### PR DESCRIPTION
- Introduced a new Party model to represent political parties with attributes for abbreviation and full name.
- Implemented functions in SchemaManager to upsert party nodes and link them to documents in Neo4j.
- Added a process_party_entities function to load party data from a JSON file and create relationships between parties and their authored documents.
- Updated main.py to call the new processing function during the main execution flow.
- Enhanced graph schema with unique constraints and indexes for party nodes.